### PR TITLE
Oasis as build dependency, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Lwt-style interface (findlib package `inotify.lwt`):
 
 ``` ocaml
 Lwt_main.run (
-  lwt inotify = Lwt_inotify.create () in
-  lwt watch   = Lwt_inotify.add_watch inotify "dir" [Inotify.S_Create] in
-  lwt event   = Lwt_inotify.read inotify in
+  let%lwt inotify = Lwt_inotify.create () in
+  let%lwt watch   = Lwt_inotify.add_watch inotify "dir" [Inotify.S_Create] in
+  let%lwt event   = Lwt_inotify.read inotify in
   Lwt_io.printl (Inotify.string_of_event event))
   (* watch=1 cookie=0 events=CREATE "file" *)
 ```

--- a/opam
+++ b/opam
@@ -1,4 +1,4 @@
-opam-version: "1"
+opam-version: "1.2"
 maintainer: "whitequark@whitequark.org"
 build: [
   ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
@@ -6,6 +6,6 @@ build: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [["ocamlfind" "remove" "inotify"]]
-depends: ["base-unix" "base-bytes" "ocamlfind"]
+depends: ["base-unix" "base-bytes" "ocamlfind" {build} "oasis" {build}]
 depopts: ["lwt"]
 os: ["linux" | "darwin"]


### PR DESCRIPTION
Having oasis installed on the system seems to be required, since 7e108f5e61a8cdcd85e10c3b26898c94d024f4e0 removed oasis-generated artifacts from the tree.

Would also be nice to cut a new release in OPAM, since there have been significant changes since the last release (eg, removing camlp4 dependency).