### PR TITLE
Add test information to the opam file

### DIFF
--- a/opam
+++ b/opam
@@ -10,12 +10,23 @@ build: [
   ["ocaml" "setup.ml" "-configure" "--%{lwt:enable}%-lwt" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
+build-test: [
+  ["ocaml" "setup.ml" "-configure"
+   "--%{lwt:enable}%-lwt" "--prefix" prefix "--enable-tests"]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test"]
+]
 install: [
   ["ocaml" "setup.ml" "-install"]
 ]
 remove: [
   ["ocamlfind" "remove" "inotify"]
 ]
-depends: ["base-unix" "base-bytes" "ocamlfind" {build}]
+depends: [
+  "base-unix"
+  "base-bytes"
+  "ocamlfind" {build}
+  "fileutils" {test}
+]
 depopts: ["lwt"]
 available: [os = "linux" | os = "darwin"]


### PR DESCRIPTION
Also, `bug-reports` lists the GitHub issue tracker but issues haven't been turned on for your repo. :-/

Other things I noticed:
 - This `opam` is used for pinning but doesn't list `oasis` as a build dependency due to dynamic configuration. Listing `oasis` would cause this file to diverge from the `opam-repository` metadata, too. :-/
 - I don't know why this file lists the library as working under `darwin`... yes, it compiles but the underlying interface isn't there so it doesn't actually work.