### PR TITLE
Add watch_of_int to support symmetric deserializers

### DIFF
--- a/lib/inotify.ml
+++ b/lib/inotify.ml
@@ -87,6 +87,8 @@ external struct_size : unit -> int = "caml_inotify_struct_size"
 
 let int_of_watch watch = watch
 
+let watch_of_int watch = watch
+
 let string_of_event (watch, events, cookie, name) =
   Printf.sprintf "watch=%d cookie=%ld events=%s%s"
                  watch cookie

--- a/lib/inotify.mli
+++ b/lib/inotify.mli
@@ -73,6 +73,15 @@ type event = watch * event_kind list * int32 * string option
     watch descriptor [wd]. *)
 val int_of_watch         : watch -> int
 
+(**/**)
+
+(* [watch_of_int i] is the {!watch} corresponding to the integer
+   [i]. It violates the construction privacy of the {!watch} type but
+   is useful when using {!event} as a network portable type. *)
+val watch_of_int         : int -> watch
+
+(**/**)
+
 (** [string_of_event_kind ek] returns the string representation of event kind [ek],
     e.g. [string_of_event_kind Move_self] ≡ ["MOVE_SELF"]. *)
 val string_of_event_kind : event_kind -> string


### PR DESCRIPTION
This reduces the privacy of the watch type but it is possible and natural to offer this functionality and abuse would be strange and obvious.