### PR TITLE
Multi distro travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: c
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash ./.travis-docker.sh
 env:
-  - OPAM_PACKAGES="lwt ounit fileutils oasis"
-script:
-  - echo "yes" | sudo add-apt-repository ppa:avsm/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq ocaml opam
-  - export OPAMYES=1
-  - opam init
-  - eval `opam config env`
-  - opam install -q -y oasis ${OPAM_PACKAGES}
-  - ./configure --enable-tests --enable-lwt
-  - make test
+ global:
+   - PACKAGE="inotify"
+   - PRE_INSTALL_HOOK="opam depext -ui oasis fileutils pcre"
+   - DEPOPTS="lwt"
+ matrix:
+   - DISTRO=debian-stable OCAML_VERSION=4.02.3
+   - DISTRO=debian-testing OCAML_VERSION=4.02.3
+   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.01.0
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
+   - DISTRO=centos-6 OCAML_VERSION=4.01.0
+   - DISTRO=centos-7 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
+   - DISTRO=alpine-3.3 OCAML_VERSION=4.02.3

--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat  : 0.4
 Name         : inotify
-Version      : 2.1
+Version      : 2.2
 Synopsis     : Inotify bindings for ocaml
 Authors      : Vincent Hanquez, Peter Zotov
 License      : LGPL-2.1 with OCaml linking exception


### PR DESCRIPTION
This adds support for testing on Debian, Ubuntu, CentOS, Fedora and Alpine (which was broken in the 2.1 release)

If this passes, any chance of an OPAM release @whitequark?  The 2.1 release is broken on Alpine, which in turn breaks Core.