### PR TITLE
always make the inotify fd CLOEXEC initially

### DIFF
--- a/lib/inotify_stubs.c
+++ b/lib/inotify_stubs.c
@@ -49,7 +49,7 @@ static int inotify_return_table[] = {
 value caml_inotify_init(value unit) {
   CAMLparam1(unit);
 
-  int fd = inotify_init();
+  int fd = inotify_init1(IN_CLOEXEC);
   if (fd == -1) uerror("inotify_init", Nothing);
 
   CAMLreturn(Val_int(fd));


### PR DESCRIPTION
The reason is to avoid leaking these fds into child processes when forking. This came up not because it was causing a bug, but because I was debugging why other fds were leaked and causing problems, and an inotify fd showed up as well.
I think this is a saner default, and I can't foresee any reason to make it customizable, so it's not customizable. But it's possible to use Unix.clear_close_on_exec if necessary.

The man page says inotify_init1 was added in linux 2.6.27, which is from 2008, so I think it's alright to use this function.