### PR TITLE
fix link for documentation

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -6,7 +6,7 @@
 (authors "whitequark <whitequark@whitequark.org>")
 (maintainers "whitequark <whitequark@whitequark.org>")
 (homepage "https://github.com/whitequark/ocaml-inotify")
-(documentation "http://whitequark.github.io/ocaml-inotify")
+(documentation "https://whitequark.github.io/ocaml-inotify")
 (bug_reports "https://github.com/whitequark/ocaml-inotify/issues")
 (source (github whitequark/ocaml-inotify))
 

--- a/inotify.opam
+++ b/inotify.opam
@@ -6,7 +6,7 @@ maintainer: ["whitequark <whitequark@whitequark.org>"]
 authors: ["whitequark <whitequark@whitequark.org>"]
 license: "LGPL-2.1"
 homepage: "https://github.com/whitequark/ocaml-inotify"
-doc: "http://whitequark.github.io/ocaml-inotify"
+doc: "https://whitequark.github.io/ocaml-inotify"
 bug-reports: "https://github.com/whitequark/ocaml-inotify/issues"
 depends: [
   "dune" {>= "2.9"}


### PR DESCRIPTION
This PR is to here to correct the concerns raised in #14 about the documentation.

Basically, it adds HTTPS to the `doc` field to support `dune-release`. However, `dune-release` witll still complain if there isn't a `CHANGES.md` file.