### PR TITLE
remove <features.h>

### DIFF
--- a/lib/inotify_stubs.c
+++ b/lib/inotify_stubs.c
@@ -28,7 +28,6 @@
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
 
-#include <features.h>
 #include <sys/inotify.h>
 
 static int inotify_flag_table[] = {


### PR DESCRIPTION
close #18

still compiles for me. Apparently it was introduced in the initial commit 8 years ago…