### PR TITLE
adds pure operators

### DIFF
--- a/lib/lwt_inotify.ml
+++ b/lib/lwt_inotify.ml
@@ -6,25 +6,30 @@ type t = {
   lwt_fd  : Lwt_unix.file_descr;
 }
 
-let create () =
-  try
+let create' () =
     let unix_fd = Inotify.create () in
-    return {
+    {
       queue   = Queue.create ();
       lwt_fd  = Lwt_unix.of_unix_file_descr unix_fd;
-      unix_fd; }
-  with exn ->
-    Lwt.fail exn
+      unix_fd;
+    }
+
+let create () = try return (create' ()) with exn -> Lwt.fail exn
+
+let add_watch' inotify path selector =
+    Inotify.add_watch inotify.unix_fd path selector
 
 let add_watch inotify path selector =
   try
-    return (Inotify.add_watch inotify.unix_fd path selector)
-  with exn ->
-    Lwt.fail exn
+    return (add_watch' inotify path selector)
+  with exn -> Lwt.fail exn
+
+let rm_watch' inotify wd =
+    Inotify.rm_watch inotify.unix_fd wd
 
 let rm_watch inotify wd =
   try
-    return (Inotify.rm_watch inotify.unix_fd wd)
+    return (rm_watch' inotify wd)
   with exn ->
     Lwt.fail exn
 

--- a/lib/lwt_inotify.mli
+++ b/lib/lwt_inotify.mli
@@ -1,17 +1,27 @@
-(** An [Lwt] wrapper for {!Inotify} module *)
+(** An [Lwt] wrapper for {!Inotify} module.
+
+    Note, whenever it is possible we provide two version of an
+    operation:
+    - [f'] - a pure non-blocking operation;
+    - [f] - the same operation lifted into the Lwt monad.
+*)
 
 (** Type of inotify descriptors. *)
 type t
 
 (** [create ()] returns a new inotify descriptor. *)
 val create    : unit -> t Lwt.t
+val create'   : unit -> t
 
 (** [add_watch desc path events] sets up [desc] to watch for [events] occuring
     to [path], and returns a watch descriptor. *)
-val add_watch : t -> string -> Inotify.selector list -> Inotify.watch Lwt.t
+val add_watch  : t -> string -> Inotify.selector list -> Inotify.watch Lwt.t
+val add_watch' : t -> string -> Inotify.selector list -> Inotify.watch
+
 
 (** [rm_watch desc watch] stops [desc] from watching [watch]. *)
 val rm_watch  : t -> Inotify.watch -> unit Lwt.t
+val rm_watch' : t -> Inotify.watch -> unit
 
 (** [read desc] waits for an event to occur at [desc]. *)
 val read      : t -> Inotify.event Lwt.t


### PR DESCRIPTION
Adds pure (non-lwt) `create'`, `add_watch'`, and `rm_watch'` operators.