### PR TITLE
dune: add dependency to unix library

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -2,6 +2,7 @@
   (name inotify)
   (public_name inotify)
   (foreign_stubs (language c) (names inotify_stubs))
+  (libraries unix)
   (modules inotify))
 
 (library


### PR DESCRIPTION
I've been getting this error without this when trying to use the library:

```
### output ###
# (cd _build/default && /home/paus/.local/share/opam/toolstack-local-no-async/bin/ocamlopt.opt -w -40 -w -39-6@5 -g -o ocaml/xapi-storage-script/main.exe /home/paus/.local/share/opam/toolstack-local-no-async/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/paus/.local/share/opam/toolstack-local-no-async/lib/base/base_internalhash_types /home/paus/.local/share/opam/toolstac[...]
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Unix referenced from /home/paus/.local/share/opam/toolstack-local-no-async/lib/inotify/inotify.cmxa(Inotify)
```

And this seems to be an easy enough fix, but I don't know whether I'm using it wrong

I'll be glad to add some missing dependency on my side. `unix` is already present in the dune dependency list of the binary, and adding `base-unix` to the opam dependency list doesn't fix it. If anybody is interested in looking into this, the branch that causes this is in https://github.com/xapi-project/xen-api/compare/master...psafont:xen-api:no-async