### PR TITLE
Fix some packaging issues

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,7 @@
   (depends
    base-unix
    base-bytes
+   (inotify (= :version))
    (fileutils (and :with-test (>= 0.4.4)))
    (ounit2 (and :with-test (>= 2.0)))
    (ocaml (>= 5.0))

--- a/inotify-eio.opam
+++ b/inotify-eio.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "3.9"}
   "base-unix"
   "base-bytes"
+  "inotify" {= version}
   "fileutils" {with-test & >= "0.4.4"}
   "ounit2" {with-test & >= "2.0"}
   "ocaml" {>= "5.0"}

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -5,6 +5,7 @@
 
 (test
  (name test_inotify_lwt)
+ (build_if %{lib-available:lwt})
  (libraries ounit2 inotify.lwt fileutils)
  (modules test_inotify_lwt))
 


### PR DESCRIPTION
Hello,

I have tried to use the Eio support (#25) by @clecat via Nix, but somehow it initially failed.

As far as I understand, `inotify-eio` package contains `eio_inotify` module but not `inotify` module, so `inotify-eio` package must depend on `inotify` package, right? This PR adds the correct dependency, and it seems to build with Nix.

Also, I have also added `flake.nix` and `flake.lock` in this PR to ensure Nix builds, but this is optional. I will remove those files if you don't like them.